### PR TITLE
Add binaries directory

### DIFF
--- a/build_template.py
+++ b/build_template.py
@@ -9,20 +9,21 @@ COMMAND["readelf.o"] = 'afl-clang-fast -DHAVE_CONFIG_H -I.  -I. -I. -I../bfd -I.
 COMMAND["objdump"] = "/bin/bash ./libtool --tag=CC   --mode=link afl-clang-fast -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread  -flto  -o $1 {object} [[objdump.o dwarf.o prdbg.o rddbg.o debug.o stabs.o ieee.o rdcoff.o bucomm.o version.o filemode.o elfcomm.o]]  ../opcodes/libopcodes.la ../bfd/libbfd.la ../libiberty/libiberty.a  -lz 1> /dev/null 2> /dev/null"
 COMMAND["objdump.o"] = 'afl-clang-fast -DHAVE_CONFIG_H -I.  -I. -I. -I../bfd -I./../bfd -I./../include -DLOCALEDIR="\\"/usr/local/share/locale\\"" -Dbin_dummy_emulation=bin_vanilla_emulation  -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread -MT objdump.o -MD -MP -MF .deps/objdump.Tpo -c -o objdump.o -DOBJDUMP_PRIVATE_VECTORS="" ./{SRC}  1> /dev/null 2> /tmp/makeout'
 
-COMMAND["nm-new"] = "/bin/bash ./libtool --tag=CC   --mode=link afl-clang-fast -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread  -flto  -o $1 {object} [[nm.o bucomm.o version.o filemode.o]] ../bfd/libbfd.la ../libiberty/libiberty.a  -lz  1> /dev/null 2> /dev/null" 
+COMMAND["nm-new"] = "/bin/bash ./libtool --tag=CC   --mode=link afl-clang-fast -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread  -flto  -o $1 {object} [[nm.o bucomm.o version.o filemode.o]] ../bfd/libbfd.la ../libiberty/libiberty.a  -lz  1> /dev/null 2> /dev/null"
 COMMAND["nm-new.o"] = 'afl-clang-fast -DHAVE_CONFIG_H -I.  -I. -I. -I../bfd -I./../bfd -I./../include -DLOCALEDIR="\\"/usr/local/share/locale\\"" -Dbin_dummy_emulation=bin_vanilla_emulation  -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread -MT nm.o -MD -MP -MF .deps/nm.Tpo -c -o nm.o {SRC}  1> /dev/null 2> /tmp/makeout'
 
 COMMAND["objcopy"] = "/bin/bash ./libtool --tag=CC   --mode=link afl-clang-fast -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread  -flto  -o $1 {object} [[objcopy.o not-strip.o rename.o rddbg.o debug.o stabs.o ieee.o rdcoff.o wrstabs.o bucomm.o version.o filemode.o]] ../bfd/libbfd.la ../libiberty/libiberty.a  -lz  1> /dev/null 2> /dev/null"
 COMMAND["objcopy.o"] = 'afl-clang-fast -DHAVE_CONFIG_H -I.  -I. -I. -I../bfd -I./../bfd -I./../include -DLOCALEDIR="\\"/usr/local/share/locale\\"" -Dbin_dummy_emulation=bin_vanilla_emulation  -W -Wall -Wstrict-prototypes -Wmissing-prototypes -Wshadow -O0 -flto -std=c11 -lpthread -MT objcopy.o -MD -MP -MF .deps/objcopy.Tpo -c -o objcopy.o {SRC}  1> /dev/null 2> /tmp/makeout'
 
 # target filename, line: header, line: wrapper for openfile, argv_num
-# argv_num: readelf -a /bin/sh ==> argv[2] 
+# argv_num: readelf -a /bin/sh ==> argv[2]
 TEMP = """#!/bin/bash
 
 if [ "$3" == "init" ]
   then
-    {OBJ_INIT}    
+    {OBJ_INIT}
     {CMD_INIT}
+    mkdir -p ../../test/binaries/
     cp $1 ../../test/binaries/
 
 elif [ "$3" == "slow" ]
@@ -38,16 +39,16 @@ elif [ "$3" == "coverage" ]
     #echo "rop"
 
 elif [ "$3" == "makeanti" ]
-  then 
+  then
     {OBJ_ANTI}
     {CMD_ANTI_TEMP}
 
 elif [ "$3" == "anti" ]
-  then 
+  then
     {CMD_ANTI}
 
 elif [ "$3" == "all" ]
-  then     
+  then
     cp {DELAY_PATH}/delay_$2.o ./delay.o
     {CMD_ALL}
 fi


### PR DESCRIPTION
Thank you for the helpful tutorial.

I found out that if we do not create a `binaries` directory, we will get the following error when executing `python compile.py`:
```
...
cp: cannot create regular file '../../test/binaries/': Not a directory
cp: cannot create regular file '../../test/binaries/': Not a directory
cp: cannot create regular file '../../test/binaries/': Not a directory
cp: cannot create regular file '../../test/binaries/': Not a directory
```

I added `mkdir -p binaries` to the `init` part of your `build_template.py` script.